### PR TITLE
Object selection

### DIFF
--- a/example/lib/draw/adapters/draw_text_adapter.dart
+++ b/example/lib/draw/adapters/draw_text_adapter.dart
@@ -29,13 +29,53 @@ class DrawTextAdapter extends DrawObjectAdapter<DrawText> {
   }
 
   @override
-  bool update(DrawText object, Offset focalPoint, Color color) {
+  bool update(
+      DrawText object, Offset focalPoint, Color color, Matrix4 transform) {
     return false;
   }
 
   @override
   bool end(DrawText object, Color color) {
     return true;
+  }
+
+  @override
+  bool querySelect(DrawText object, Offset focalPoint, Matrix4 transform) {
+    // TODO: implement querySelect
+    return false;
+  }
+
+  @override
+  void select(DrawText object) {
+    // TODO: implement select
+  }
+
+  @override
+  void cancelSelect(DrawText object) {
+    // TODO: implement cancelSelect
+  }
+
+  @override
+  bool selectedStart(DrawText object, Offset focalPoint, Matrix4 transform) {
+    // TODO: implement selectedStart
+    return false;
+  }
+
+  @override
+  bool selectedUpdate(DrawText object, Offset focalPoint, Matrix4 transform) {
+    // TODO: implement selectedUpdate
+    return false;
+  }
+
+  @override
+  bool selectedEnd(DrawText object) {
+    // TODO: implement selectedEnd
+    return false;
+  }
+
+  @override
+  void selectUpdateColor(DrawText object, Color color) {
+    object.anchor.paint.color = color;
   }
 
   DrawPoint _createPoint(Offset offset, Color color) {

--- a/example/lib/draw/objects/draw_text.dart
+++ b/example/lib/draw/objects/draw_text.dart
@@ -1,7 +1,9 @@
 import 'dart:ui';
 
+import 'package:example/draw/adapters/draw_text_adapter.dart';
 import 'package:flutter/painting.dart';
 import 'package:window_paint/src/draw/draw_object.dart';
+import 'package:window_paint/src/draw/draw_object_adapter.dart';
 import 'package:window_paint/src/draw/draw_point.dart';
 
 class DrawText extends DrawObject {
@@ -15,7 +17,7 @@ class DrawText extends DrawObject {
 
   String text;
   double fontSize;
-  String? _lastPaintedText;
+  String? _paintedText;
 
   TextStyle get textStyle => TextStyle(
         color: anchor.paint.color,
@@ -36,12 +38,18 @@ class DrawText extends DrawObject {
         maxWidth: size.width - anchor.offset.dx,
       );
     textPainter.paint(canvas, anchor.offset);
-    _lastPaintedText = text;
+    _paintedText = text;
   }
 
   @override
-  bool shouldRepaint() => text != _lastPaintedText;
+  bool shouldRepaint() => text != _paintedText;
 
   @override
   void finalize() {}
+
+  @override
+  DrawObjectAdapter<DrawObject> get adapter => const DrawTextAdapter();
+
+  @override
+  Color get primaryColor => anchor.paint.color;
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -39,6 +39,8 @@ class _MyHomePageState extends State<MyHomePage> {
     initialColor: Colors.red,
   );
 
+  var debugHitboxes = false;
+
   @override
   void dispose() {
     _windowPaintController.dispose();
@@ -47,7 +49,6 @@ class _MyHomePageState extends State<MyHomePage> {
 
   @override
   Widget build(BuildContext context) {
-    const debugHitboxes = false;
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.title),
@@ -63,7 +64,7 @@ class _MyHomePageState extends State<MyHomePage> {
               ),
               WindowPaint(
                 controller: _windowPaintController,
-                adapters: const {
+                adapters: {
                   'pan_zoom': PanZoomAdapter(),
                   'pencil': DrawPencilAdapter(
                     debugHitboxes: debugHitboxes,
@@ -81,6 +82,20 @@ class _MyHomePageState extends State<MyHomePage> {
                     color: Colors.amber[100],
                   ),
                   height: 400,
+                ),
+              ),
+              RaisedButton(
+                onPressed: () {
+                  setState(() {
+                    debugHitboxes = !debugHitboxes;
+                  });
+                },
+                color: debugHitboxes ? Colors.green : Colors.amber,
+                child: SizedBox(
+                  width: 92.0,
+                  child: Center(
+                    child: Text('Hitboxes ${debugHitboxes ? 'ON' : 'OFF'}'),
+                  ),
                 ),
               ),
             ],

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:example/draw/adapters/draw_text_adapter.dart';
 import 'package:example/window_paint_control.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:window_paint/window_paint.dart';
 
@@ -46,6 +47,7 @@ class _MyHomePageState extends State<MyHomePage> {
 
   @override
   Widget build(BuildContext context) {
+    const debugHitboxes = false;
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.title),
@@ -63,9 +65,15 @@ class _MyHomePageState extends State<MyHomePage> {
                 controller: _windowPaintController,
                 adapters: const {
                   'pan_zoom': PanZoomAdapter(),
-                  'pencil': DrawPencilAdapter(),
-                  'rectangle': DrawRectangleAdapter(),
-                  'rectangle_cross': DrawRectangleCrossAdapter(),
+                  'pencil': DrawPencilAdapter(
+                    debugHitboxes: debugHitboxes,
+                  ),
+                  'rectangle': DrawRectangleAdapter(
+                    debugHitboxes: debugHitboxes,
+                  ),
+                  'rectangle_cross': DrawRectangleCrossAdapter(
+                    debugHitboxes: debugHitboxes,
+                  ),
                   'text': DrawTextAdapter(),
                 },
                 child: Container(

--- a/example/lib/window_paint_control.dart
+++ b/example/lib/window_paint_control.dart
@@ -76,7 +76,12 @@ class _WindowPaintControlState extends State<WindowPaintControl> {
             },
           ),
           IconButton(
-            icon: Icon(Icons.color_lens, color: widget.controller.color),
+            icon: ValueListenableBuilder<WindowPaintValue>(
+              valueListenable: widget.controller,
+              builder: (context, value, child) {
+                return Icon(Icons.color_lens, color: widget.controller.color);
+              },
+            ),
             onPressed: _showColorPicker,
           ),
         ],
@@ -100,7 +105,7 @@ class _WindowPaintControlState extends State<WindowPaintControl> {
 
   Future<void> _showColorPicker() async {
     var pickedColor = widget.controller.color;
-    final confirmed = await showDialog(
+    final confirmed = await showDialog<bool>(
       context: context,
       builder: (context) {
         return AlertDialog(
@@ -130,7 +135,7 @@ class _WindowPaintControlState extends State<WindowPaintControl> {
         );
       },
     );
-    if (confirmed) {
+    if (confirmed == true) {
       widget.controller.color = pickedColor;
     }
   }

--- a/lib/src/draw/adapters/draw_pencil_adapter.dart
+++ b/lib/src/draw/adapters/draw_pencil_adapter.dart
@@ -7,23 +7,25 @@ import 'package:window_paint/src/draw/draw_point.dart';
 import 'package:window_paint/src/draw/objects/draw_pencil.dart';
 
 class DrawPencilAdapter extends DrawObjectAdapter<DrawPencil> {
-  const DrawPencilAdapter();
+  const DrawPencilAdapter({
+    this.debugHitboxes = false,
+  });
+
+  final bool debugHitboxes;
 
   @override
   FutureOr<DrawPencil?> start(
-    BuildContext context,
-    Offset focalPoint,
-    Color color,
-    Matrix4 transform,
-  ) {
+      BuildContext context, Offset focalPoint, Color color, Matrix4 transform) {
     final point = _createPoint(focalPoint, color);
     return DrawPencil(
       points: [point],
+      debugHitboxes: debugHitboxes,
     );
   }
 
   @override
-  bool update(DrawPencil object, Offset focalPoint, Color color) {
+  bool update(
+      DrawPencil object, Offset focalPoint, Color color, Matrix4 transform) {
     final point = _createPoint(focalPoint, color);
     object.addPoint(point);
     return true;
@@ -33,6 +35,43 @@ class DrawPencilAdapter extends DrawObjectAdapter<DrawPencil> {
   bool end(DrawPencil object, Color color) {
     object.simplify();
     return true;
+  }
+
+  @override
+  bool querySelect(DrawPencil object, Offset focalPoint, Matrix4 transform) {
+    return object.hitboxes.any((hitbox) => hitbox.contains(focalPoint));
+  }
+
+  @override
+  void select(DrawPencil object) {
+    object.selected = true;
+  }
+
+  @override
+  void cancelSelect(DrawPencil object) {
+    object.selected = false;
+  }
+
+  @override
+  bool selectedStart(DrawPencil object, Offset focalPoint, Matrix4 transform) {
+    return object.hitboxes.any((hitbox) => hitbox.contains(focalPoint));
+  }
+
+  @override
+  bool selectedUpdate(DrawPencil object, Offset focalPoint, Matrix4 transform) {
+    return false;
+  }
+
+  @override
+  bool selectedEnd(DrawPencil object) {
+    return true;
+  }
+
+  @override
+  void selectUpdateColor(DrawPencil object, Color color) {
+    for (final point in object.points) {
+      point.paint.color = color;
+    }
   }
 
   DrawPoint _createPoint(Offset offset, Color color) {

--- a/lib/src/draw/adapters/draw_rectangle_adapter.dart
+++ b/lib/src/draw/adapters/draw_rectangle_adapter.dart
@@ -7,23 +7,25 @@ import 'package:window_paint/src/draw/draw_point.dart';
 import 'package:window_paint/src/draw/objects/draw_rectangle.dart';
 
 class DrawRectangleAdapter extends DrawObjectAdapter<DrawRectangle> {
-  const DrawRectangleAdapter();
+  const DrawRectangleAdapter({
+    this.debugHitboxes = false,
+  });
+
+  final bool debugHitboxes;
 
   @override
   FutureOr<DrawRectangle?> start(
-    BuildContext context,
-    Offset focalPoint,
-    Color color,
-    Matrix4 transform,
-  ) {
+      BuildContext context, Offset focalPoint, Color color, Matrix4 transform) {
     final point = _createPoint(focalPoint, color);
     return DrawRectangle(
       anchor: point,
+      debugHitboxes: debugHitboxes,
     );
   }
 
   @override
-  bool update(DrawRectangle object, Offset focalPoint, Color color) {
+  bool update(
+      DrawRectangle object, Offset focalPoint, Color color, Matrix4 transform) {
     object.endpoint = focalPoint;
     return true;
   }
@@ -31,6 +33,43 @@ class DrawRectangleAdapter extends DrawObjectAdapter<DrawRectangle> {
   @override
   bool end(DrawRectangle object, Color color) {
     return true;
+  }
+
+  @override
+  bool querySelect(DrawRectangle object, Offset focalPoint, Matrix4 transform) {
+    return object.hitboxes.any((hitbox) => hitbox.contains(focalPoint));
+  }
+
+  @override
+  void select(DrawRectangle object) {
+    object.selected = true;
+  }
+
+  @override
+  void cancelSelect(DrawRectangle object) {
+    object.selected = false;
+  }
+
+  @override
+  bool selectedStart(
+      DrawRectangle object, Offset focalPoint, Matrix4 transform) {
+    return object.hitboxes.any((hitbox) => hitbox.contains(focalPoint));
+  }
+
+  @override
+  bool selectedUpdate(
+      DrawRectangle object, Offset focalPoint, Matrix4 transform) {
+    return false;
+  }
+
+  @override
+  bool selectedEnd(DrawRectangle object) {
+    return true;
+  }
+
+  @override
+  void selectUpdateColor(DrawRectangle object, Color color) {
+    object.anchor.paint.color = color;
   }
 
   DrawPoint _createPoint(Offset offset, Color color) {

--- a/lib/src/draw/adapters/draw_rectangle_cross_adapter.dart
+++ b/lib/src/draw/adapters/draw_rectangle_cross_adapter.dart
@@ -7,23 +7,25 @@ import 'package:window_paint/src/draw/draw_point.dart';
 import 'package:window_paint/src/draw/objects/draw_rectangle_cross.dart';
 
 class DrawRectangleCrossAdapter extends DrawObjectAdapter<DrawRectangleCross> {
-  const DrawRectangleCrossAdapter();
+  const DrawRectangleCrossAdapter({
+    this.debugHitboxes = false,
+  });
+
+  final bool debugHitboxes;
 
   @override
   FutureOr<DrawRectangleCross?> start(
-    BuildContext context,
-    Offset focalPoint,
-    Color color,
-    Matrix4 transform,
-  ) {
+      BuildContext context, Offset focalPoint, Color color, Matrix4 transform) {
     final point = _createPoint(focalPoint, color);
     return DrawRectangleCross(
       anchor: point,
+      debugHitboxes: debugHitboxes,
     );
   }
 
   @override
-  bool update(DrawRectangleCross object, Offset focalPoint, Color color) {
+  bool update(DrawRectangleCross object, Offset focalPoint, Color color,
+      Matrix4 transform) {
     object.endpoint = focalPoint;
     return true;
   }
@@ -31,6 +33,47 @@ class DrawRectangleCrossAdapter extends DrawObjectAdapter<DrawRectangleCross> {
   @override
   bool end(DrawRectangleCross object, Color color) {
     return true;
+  }
+
+  @override
+  bool querySelect(
+      DrawRectangleCross object, Offset focalPoint, Matrix4 transform) {
+    return object.hitboxes.any((hitbox) => hitbox.contains(focalPoint)) ||
+        object.innerHitboxes.any((hitbox) => hitbox.contains(focalPoint));
+  }
+
+  @override
+  void select(DrawRectangleCross object) {
+    object.selected = true;
+  }
+
+  @override
+  void cancelSelect(DrawRectangleCross object) {
+    object.selected = false;
+  }
+
+  @override
+  bool selectedStart(
+      DrawRectangleCross object, Offset focalPoint, Matrix4 transform) {
+    return object.hitboxes.any((hitbox) => hitbox.contains(focalPoint));
+  }
+
+  @override
+  bool selectedUpdate(
+      DrawRectangleCross object, Offset focalPoint, Matrix4 transform) {
+    // TODO: implement selectedUpdate
+    return true;
+  }
+
+  @override
+  bool selectedEnd(DrawRectangleCross object) {
+    // TODO: implement selectedEnd
+    return true;
+  }
+
+  @override
+  void selectUpdateColor(DrawRectangleCross object, Color color) {
+    object.anchor.paint.color = color;
   }
 
   DrawPoint _createPoint(Offset offset, Color color) {

--- a/lib/src/draw/adapters/pan_zoom_adapter.dart
+++ b/lib/src/draw/adapters/pan_zoom_adapter.dart
@@ -27,7 +27,7 @@ class PanZoomAdapter extends DrawObjectAdapter<DrawNoop> {
   }
 
   @override
-  bool get panEnabled => true;
+  bool get panScaleEnabled => true;
   @override
-  bool get scaleEnabled => true;
+  bool get selectEnabled => true;
 }

--- a/lib/src/draw/adapters/pan_zoom_adapter.dart
+++ b/lib/src/draw/adapters/pan_zoom_adapter.dart
@@ -10,21 +10,51 @@ class PanZoomAdapter extends DrawObjectAdapter<DrawNoop> {
 
   @override
   FutureOr<DrawNoop?> start(
-    BuildContext context,
-    Offset focalPoint,
-    Color color,
-    Matrix4 transform,
-  ) {
+      BuildContext context, Offset focalPoint, Color color, Matrix4 transform) {
     return DrawNoop();
   }
 
   @override
-  bool update(DrawNoop object, Offset focalPoint, Color color) => false;
+  bool update(
+      DrawNoop object, Offset focalPoint, Color color, Matrix4 transform) {
+    return false;
+  }
 
   @override
   bool end(DrawNoop object, Color color) {
     return false;
   }
+
+  @override
+  bool querySelect(DrawNoop object, Offset focalPoint, Matrix4 transform) {
+    return false;
+  }
+
+  @override
+  void select(DrawNoop object) {
+    // TODO: implement select
+  }
+
+  @override
+  void cancelSelect(DrawNoop object) {
+    // TODO: implement cancelSelect
+  }
+
+  @override
+  bool selectedStart(DrawNoop object, Offset focalPoint, Matrix4 transform) {
+    return false;
+  }
+
+  @override
+  bool selectedUpdate(DrawNoop object, Offset focalPoint, Matrix4 transform) {
+    return false;
+  }
+
+  @override
+  bool selectedEnd(DrawNoop object) => false;
+
+  @override
+  void selectUpdateColor(DrawNoop object, Color color) {}
 
   @override
   bool get panScaleEnabled => true;

--- a/lib/src/draw/draw_object.dart
+++ b/lib/src/draw/draw_object.dart
@@ -1,7 +1,13 @@
 import 'package:flutter/widgets.dart';
+import 'package:window_paint/src/draw/draw_object_adapter.dart';
 
 abstract class DrawObject {
   void paint(Canvas canvas, Size size);
   bool shouldRepaint();
   void finalize();
+
+  DrawObjectAdapter get adapter;
+
+  /// Used primarily for updating [WindowPaintController.color] when selected.
+  Color get primaryColor;
 }

--- a/lib/src/draw/draw_object_adapter.dart
+++ b/lib/src/draw/draw_object_adapter.dart
@@ -24,18 +24,15 @@ abstract class DrawObjectAdapter<T extends DrawObject> {
 
   /// Returning [true] will trigger a re-paint.
   ///
-  /// This is useful for things like pan/zoom
-  /// where you don't paint anything.
+  /// This is useful for things like pan/zoom where you don't paint anything.
   ///
   /// NOTE: Will not be called if [start] returned a [Future].
   bool update(T object, Offset focalPoint, Color color);
 
-  /// Returning [true] will keep the object,
-  /// [false] will discard it.
+  /// Returning [true] will keep the object, [false] will discard it.
   ///
-  /// This is useful for things like pan/zoom
-  /// where you want to fulfill the contract,
-  /// but not draw anything.
+  /// This is useful for things like pan/zoom where you want to fulfill the
+  /// contract, but not draw anything.
   ///
   /// NOTE: Will not be called if [start] returned a [Future].
   bool end(T object, Color color);

--- a/lib/src/draw/draw_object_adapter.dart
+++ b/lib/src/draw/draw_object_adapter.dart
@@ -16,31 +16,53 @@ abstract class DrawObjectAdapter<T extends DrawObject> {
   /// until the [Future] completes. The [Future] should complete with either
   /// a fully constructed [DrawObject], or [null] to discard it.
   FutureOr<T?> start(
-    BuildContext context,
-    Offset focalPoint,
-    Color color,
-    Matrix4 transform,
-  );
+      BuildContext context, Offset focalPoint, Color color, Matrix4 transform);
 
   /// Returning [true] will trigger a re-paint.
   ///
-  /// This is useful for things like pan/zoom where you don't paint anything.
+  /// Useful for pan/zoom where you don't paint anything.
   ///
   /// NOTE: Will not be called if [start] returned a [Future].
-  bool update(T object, Offset focalPoint, Color color);
+  bool update(T object, Offset focalPoint, Color color, Matrix4 transform);
 
   /// Returning [true] will keep the object, [false] will discard it.
   ///
-  /// This is useful for things like pan/zoom where you want to fulfill the
-  /// contract, but not draw anything.
+  /// Useful for pan/zoom where you want to fulfill the contract, but not
+  /// draw anything.
   ///
   /// NOTE: Will not be called if [start] returned a [Future].
   bool end(T object, Color color);
 
   /// Returning [true] will select the object.
   ///
-  /// This is useful when you only want to select an object by its visible area.
-  bool select(T object, Offset focalPoint, Matrix4 transform) => true;
+  /// This is needed as the consumer can't know a DrawObject's size or position.
+  bool querySelect(T object, Offset focalPoint, Matrix4 transform);
+
+  /// The object has been chosen as the selected object. It should render its
+  /// hitbox and interactive handles, if any.
+  void select(T object);
+
+  /// The object is no longer being selected. It should no longer render its
+  /// hitbox and interactive handles.
+  void cancelSelect(T object);
+
+  /// Returning [false] will cancel the selection of the object, in which case
+  /// [selectedUpdate] and [selectedEnd] will not be called for the
+  /// same interaction.
+  ///
+  /// Useful for resize handles or moving the object.
+  bool selectedStart(T object, Offset focalPoint, Matrix4 transform);
+
+  /// Returning [true] will trigger a re-paint.
+  ///
+  /// Useful for interacting with resize handles or moving the object.
+  bool selectedUpdate(T object, Offset focalPoint, Matrix4 transform);
+
+  /// Returning [false] will cancel the selection of the object.
+  bool selectedEnd(T object);
+
+  /// Triggered by a change in [color] when an object is selected.
+  void selectUpdateColor(T object, Color color);
 
   bool get panScaleEnabled => false;
   bool get selectEnabled => false;

--- a/lib/src/draw/draw_object_adapter.dart
+++ b/lib/src/draw/draw_object_adapter.dart
@@ -37,6 +37,11 @@ abstract class DrawObjectAdapter<T extends DrawObject> {
   /// NOTE: Will not be called if [start] returned a [Future].
   bool end(T object, Color color);
 
+  /// Returning [true] will select the object.
+  ///
+  /// This is useful when you only want to select an object by its visible area.
+  bool select(T object, Offset focalPoint, Matrix4 transform) => true;
+
   bool get panScaleEnabled => false;
   bool get selectEnabled => false;
 }

--- a/lib/src/draw/draw_object_adapter.dart
+++ b/lib/src/draw/draw_object_adapter.dart
@@ -40,6 +40,6 @@ abstract class DrawObjectAdapter<T extends DrawObject> {
   /// NOTE: Will not be called if [start] returned a [Future].
   bool end(T object, Color color);
 
-  bool get panEnabled => false;
-  bool get scaleEnabled => false;
+  bool get panScaleEnabled => false;
+  bool get selectEnabled => false;
 }

--- a/lib/src/draw/objects/draw_noop.dart
+++ b/lib/src/draw/objects/draw_noop.dart
@@ -1,6 +1,8 @@
 import 'dart:ui';
 
+import 'package:window_paint/src/draw/adapters/pan_zoom_adapter.dart';
 import 'package:window_paint/src/draw/draw_object.dart';
+import 'package:window_paint/src/draw/draw_object_adapter.dart';
 
 class DrawNoop extends DrawObject {
   @override
@@ -11,4 +13,10 @@ class DrawNoop extends DrawObject {
 
   @override
   void finalize() {}
+
+  @override
+  DrawObjectAdapter<DrawObject> get adapter => const PanZoomAdapter();
+
+  @override
+  Color get primaryColor => Color(0xFF000000);
 }

--- a/lib/src/draw/objects/draw_rectangle.dart
+++ b/lib/src/draw/objects/draw_rectangle.dart
@@ -1,33 +1,93 @@
 import 'dart:ui';
 
+import 'package:flutter/foundation.dart';
+import 'package:window_paint/src/draw/adapters/draw_rectangle_adapter.dart';
 import 'package:window_paint/src/draw/draw_object.dart';
+import 'package:window_paint/src/draw/draw_object_adapter.dart';
 import 'package:window_paint/src/draw/draw_point.dart';
 
 class DrawRectangle extends DrawObject {
   DrawRectangle({
     required this.anchor,
+    this.debugHitboxes = false,
   });
 
   final DrawPoint anchor;
+  final bool debugHitboxes;
+
+  bool selected = false;
 
   Offset? _endpoint;
-  Offset? _lastPaintedEndpoint;
+
+  Offset? _paintedEndpoint;
+  bool _paintedSelected = false;
 
   set endpoint(Offset endpoint) {
     _endpoint = endpoint;
   }
 
-  Rect get rect => Rect.fromPoints(anchor.offset, _endpoint ?? anchor.offset);
+  Offset get effectiveEndpoint => _endpoint ?? anchor.offset;
+
+  Rect get rect => Rect.fromPoints(anchor.offset, effectiveEndpoint);
+
+  Iterable<Rect> get hitboxes sync* {
+    final a = anchor.offset;
+    final e = effectiveEndpoint;
+    // top
+    yield Rect.fromLTRB(a.dx, a.dy, e.dx, a.dy).inflate(5.0);
+    // right
+    yield Rect.fromLTRB(e.dx, a.dy, e.dx, e.dy).inflate(5.0);
+    // bottom
+    yield Rect.fromLTRB(a.dx, e.dy, e.dx, e.dy).inflate(5.0);
+    // left
+    yield Rect.fromLTRB(a.dx, a.dy, a.dx, e.dy).inflate(5.0);
+  }
+
+  Rect get outline => rect.inflate(5.0);
 
   @override
   void paint(Canvas canvas, Size size) {
     canvas.drawRect(rect, anchor.paint);
-    _lastPaintedEndpoint = _endpoint;
+    if (selected) {
+      _paintOutline(canvas, size);
+    }
+    if (!kReleaseMode && debugHitboxes) {
+      paintHitboxes(canvas, size);
+    }
+    _paintedEndpoint = _endpoint;
+    _paintedSelected = selected;
+  }
+
+  void _paintOutline(Canvas canvas, Sizesize) {
+    final paint = Paint()
+      ..color = Color(0x8A000000)
+      ..strokeWidth = 1
+      ..style = PaintingStyle.stroke;
+    canvas.drawRect(outline, paint);
+  }
+
+  /// Useful for debugging hitboxes.
+  @protected
+  void paintHitboxes(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = Color(0x8A000000)
+      ..strokeWidth = 1
+      ..style = PaintingStyle.stroke;
+    for (final hitbox in hitboxes) {
+      canvas.drawRect(hitbox, paint);
+    }
   }
 
   @override
-  bool shouldRepaint() => _endpoint != _lastPaintedEndpoint;
+  bool shouldRepaint() =>
+      _endpoint != _paintedEndpoint || selected != _paintedSelected;
 
   @override
   void finalize() {}
+
+  @override
+  DrawObjectAdapter<DrawRectangle> get adapter => const DrawRectangleAdapter();
+
+  @override
+  Color get primaryColor => anchor.paint.color;
 }

--- a/lib/src/draw/objects/draw_rectangle_cross.dart
+++ b/lib/src/draw/objects/draw_rectangle_cross.dart
@@ -1,14 +1,37 @@
 import 'dart:ui';
 
+import 'package:vector_math/vector_math_64.dart';
+import 'package:window_paint/src/draw/adapters/draw_rectangle_cross_adapter.dart';
+import 'package:window_paint/src/draw/draw_object_adapter.dart';
 import 'package:window_paint/src/draw/draw_point.dart';
 import 'package:window_paint/src/draw/objects/draw_rectangle.dart';
+import 'package:window_paint/src/geometry/line.dart';
 
 class DrawRectangleCross extends DrawRectangle {
   DrawRectangleCross({
     required DrawPoint anchor,
+    bool debugHitboxes = false,
   }) : super(
           anchor: anchor,
+          debugHitboxes: debugHitboxes,
         );
+
+  Iterable<Line> get innerHitboxes sync* {
+    final a = anchor.offset;
+    final e = effectiveEndpoint;
+    // top-left -> bottom-right
+    yield Line(
+      start: a,
+      end: e,
+      width: 5.0,
+    );
+    // bottom-left -> top-right
+    yield Line(
+      start: Offset(a.dx, e.dy),
+      end: Offset(e.dx, a.dy),
+      width: 5.0,
+    );
+  }
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -17,4 +40,27 @@ class DrawRectangleCross extends DrawRectangle {
     canvas.drawLine(rect.topLeft, rect.bottomRight, anchor.paint);
     canvas.drawLine(rect.bottomLeft, rect.topRight, anchor.paint);
   }
+
+  @override
+  void paintHitboxes(Canvas canvas, Size size) {
+    super.paintHitboxes(canvas, size);
+    final paint = Paint()
+      ..color = Color(0x8A000000)
+      ..strokeWidth = 1
+      ..style = PaintingStyle.stroke;
+    for (final hitbox in innerHitboxes) {
+      final a = Offset(hitbox.a.x, hitbox.a.y);
+      final b = Offset(hitbox.b.x, hitbox.b.y);
+      final c = Offset(hitbox.c.x, hitbox.c.y);
+      final d = Offset(hitbox.d.x, hitbox.d.y);
+      canvas.drawLine(a, b, paint);
+      canvas.drawLine(b, c, paint);
+      canvas.drawLine(c, d, paint);
+      canvas.drawLine(d, a, paint);
+    }
+  }
+
+  @override
+  DrawObjectAdapter<DrawRectangleCross> get adapter =>
+      const DrawRectangleCrossAdapter();
 }

--- a/lib/src/geometry/line.dart
+++ b/lib/src/geometry/line.dart
@@ -1,0 +1,66 @@
+import 'dart:ui';
+
+import 'package:vector_math/vector_math_64.dart';
+
+class Line {
+  Line({
+    required this.start,
+    required this.end,
+    this.width = 1.0,
+  }) {
+    final dx = end.dx - start.dx;
+    final dy = end.dy - start.dy;
+    normal = Vector2(-dy, dx)
+      ..normalize()
+      ..scale(width);
+
+    final s = Vector2(start.dx, start.dy);
+    final e = Vector2(end.dx, end.dy);
+    a = s + normal;
+    b = e + normal;
+    c = e - normal;
+    d = s - normal;
+  }
+
+  /// Start of the line.
+  final Offset start;
+
+  /// End of the line.
+  final Offset end;
+
+  /// Width of the line.
+  final double width;
+
+  /// The normal vector to this. Its magnitude is equal to [width].
+  late final Vector2 normal;
+
+  /// The A corner.
+  late final Vector2 a;
+
+  /// The B corner.
+  late final Vector2 b;
+
+  /// The C corner.
+  late final Vector2 c;
+
+  /// The D corner.
+  late final Vector2 d;
+
+  bool contains(Offset offset) {
+    final m = Vector2(offset.dx, offset.dy);
+
+    final ab = b - a;
+    final ad = d - a;
+    final am = m - a;
+
+    var dotAMAB = am.dot(ab);
+    var dotABAB = ab.dot(ab);
+    var dotAMAD = am.dot(ad);
+    var dotADAD = ad.dot(ad);
+
+    return 0 <= dotAMAB &&
+        dotAMAB <= dotABAB &&
+        0 <= dotAMAD &&
+        dotAMAD <= dotADAD;
+  }
+}

--- a/lib/src/window_paint.dart
+++ b/lib/src/window_paint.dart
@@ -51,6 +51,11 @@ class _WindowPaintState extends State<WindowPaint> with RestorationMixin {
   WindowPaintController get _effectiveController =>
       widget.controller ?? _controller!.value;
 
+  /// The color of the [controller] before an object was selected, if any.
+  /// Will be restored to the controller when the selected object is no
+  /// longer selected.
+  Color? _colorBeforeSelection;
+
   @override
   void initState() {
     super.initState();
@@ -109,8 +114,19 @@ class _WindowPaintState extends State<WindowPaint> with RestorationMixin {
         valueListenable: _effectiveController,
         builder: (context, value, child) {
           return WindowPaintCanvas(
-            color: _effectiveController.color,
-            adapter: widget.adapters[_effectiveController.mode]!,
+            color: value.color,
+            onSelectionStart: (object) {
+              _colorBeforeSelection = _effectiveController.color;
+              _effectiveController.color = object.primaryColor;
+            },
+            onSelectionEnd: (object) {
+              final colorToRestore = _colorBeforeSelection;
+              if (colorToRestore != null) {
+                _colorBeforeSelection = null;
+                _effectiveController.color = colorToRestore;
+              }
+            },
+            adapter: widget.adapters[value.mode]!,
             child: child!,
           );
         },

--- a/lib/src/window_paint_canvas.dart
+++ b/lib/src/window_paint_canvas.dart
@@ -35,11 +35,11 @@ class _WindowPaintCanvasState extends State<WindowPaintCanvas> {
     _lockedTransform = _transformationController.value;
     _transformationController.addListener(() {
       /// In newer versions of [InteractiveViewer], the [onInteractionUpdate]
-      /// callback is not called when [panEnabled] and [scaleEnabled] are false.
+      /// callback is not called when [panScaleEnabled] is [false].
       ///
       /// To overcome this limitation, we have to manually reset the
       /// transformation with the [transformationController].
-      if (widget.adapter.panEnabled || widget.adapter.scaleEnabled) {
+      if (widget.adapter.panScaleEnabled) {
         _lockedTransform = _transformationController.value;
       } else if (_transformationController.value != _lockedTransform) {
         _transformationController.value = _lockedTransform;

--- a/lib/src/window_paint_canvas.dart
+++ b/lib/src/window_paint_canvas.dart
@@ -9,10 +9,14 @@ class WindowPaintCanvas extends StatefulWidget {
   final Color color;
   final DrawObjectAdapter adapter;
   final Widget child;
+  final void Function(DrawObject)? onSelectionStart;
+  final void Function(DrawObject)? onSelectionEnd;
 
   const WindowPaintCanvas({
     Key? key,
     this.color = const Color(0xFF000000),
+    this.onSelectionStart,
+    this.onSelectionEnd,
     required this.adapter,
     required this.child,
   }) : super(key: key);
@@ -40,22 +44,43 @@ class _WindowPaintCanvasState extends State<WindowPaintCanvas> {
   /// their events for this interaction.
   Future<DrawObject?>? _pendingObject;
 
+  /// Reference to the currently selected [DrawObject] in [_objects], if any.
+  DrawObject? _selectedObject;
+
+  /// Whether or not we're currently selecting a [DrawObject].
+  bool get _isSelecting => _selectedObject != null;
+
   @override
   void initState() {
     super.initState();
     _lockedTransform = _transformationController.value;
-    _transformationController.addListener(() {
-      /// In newer versions of [InteractiveViewer], the [onInteractionUpdate]
-      /// callback is not called when [panScaleEnabled] is [false].
-      ///
-      /// To overcome this limitation, we have to manually reset the
-      /// transformation with the [transformationController].
-      if (widget.adapter.panScaleEnabled) {
-        _lockedTransform = _transformationController.value;
-      } else if (_transformationController.value != _lockedTransform) {
-        _transformationController.value = _lockedTransform;
+    _transformationController.addListener(_transformationControllerListener);
+  }
+
+  void _transformationControllerListener() {
+    /// In newer versions of [InteractiveViewer], the [onInteractionUpdate]
+    /// callback is not called when [panScaleEnabled] is [false].
+    ///
+    /// To overcome this limitation, we have to manually reset the
+    /// transformation with the [transformationController].
+    ///
+    /// We also do this if an object is selected.
+    if (widget.adapter.panScaleEnabled && _selectedObject == null) {
+      _lockedTransform = _transformationController.value;
+    } else if (_transformationController.value != _lockedTransform) {
+      _transformationController.value = _lockedTransform;
+    }
+  }
+
+  @override
+  void didUpdateWidget(WindowPaintCanvas oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (_isSelecting) {
+      if (widget.color != oldWidget.color) {
+        _selectedObject!.adapter
+            .selectUpdateColor(_selectedObject!, widget.color);
       }
-    });
+    }
   }
 
   @override
@@ -89,6 +114,15 @@ class _WindowPaintCanvasState extends State<WindowPaintCanvas> {
       details.localFocalPoint,
     );
     final transform = _transformationController.value.clone();
+    if (_isSelecting) {
+      _onInteractionStartSelected(_selectedObject!, focalPointScene, transform);
+      if (_isSelecting) {
+        return;
+      }
+    }
+    if (_trySelectObject(focalPointScene, transform)) {
+      return;
+    }
     final pending = widget.adapter.start(
       context,
       focalPointScene,
@@ -102,12 +136,21 @@ class _WindowPaintCanvasState extends State<WindowPaintCanvas> {
     }
   }
 
+  void _onInteractionStartSelected(
+    DrawObject object,
+    Offset focalPoint,
+    Matrix4 transform,
+  ) {
+    if (object.adapter.selectedStart(object, focalPoint, transform)) {
+      _startInteraction();
+    }
+    _cancelSelectObject();
+  }
+
   void _onInteractionStartSync(DrawObject? object) {
     if (object != null) {
-      setState(() {
-        _objects.add(object);
-        _hasActiveInteraction = true;
-      });
+      _addObject(object);
+      _startInteraction();
     }
   }
 
@@ -117,9 +160,7 @@ class _WindowPaintCanvasState extends State<WindowPaintCanvas> {
     _pendingObject = pending;
     final object = await pending;
     if (object != null) {
-      setState(() {
-        _objects.add(object);
-      });
+      _addObject(object);
     }
   }
 
@@ -127,17 +168,26 @@ class _WindowPaintCanvasState extends State<WindowPaintCanvas> {
     if (_pendingObject != null) {
       return;
     }
-    final object = _objects.last;
-    final focalPointScene = _transformationController.toScene(
-      details.localFocalPoint,
-    );
-    final repaint = widget.adapter.update(
-      object,
-      focalPointScene,
-      widget.color,
-    );
-    if (repaint) {
-      setState(() {});
+    if (_hasActiveInteraction) {
+      final focalPointScene = _transformationController.toScene(
+        details.localFocalPoint,
+      );
+      final transform = _transformationController.value.clone();
+      final repaint = _isSelecting
+          ? _selectedObject!.adapter.selectedUpdate(
+              _selectedObject!,
+              focalPointScene,
+              transform,
+            )
+          : widget.adapter.update(
+              _objects.last,
+              focalPointScene,
+              widget.color,
+              transform,
+            );
+      if (repaint) {
+        setState(() {});
+      }
     }
   }
 
@@ -148,13 +198,70 @@ class _WindowPaintCanvasState extends State<WindowPaintCanvas> {
       _pendingObject = null;
       return;
     }
-    final object = _objects.last;
-    setState(() {
-      final keep = widget.adapter.end(object, widget.color);
-      if (!keep) {
-        _objects.removeLast();
+    if (_hasActiveInteraction) {
+      if (_isSelecting) {
+        final remain = _selectedObject!.adapter.selectedEnd(_selectedObject!);
+        if (!remain) {
+          _cancelSelectObject();
+        }
+      } else {
+        final object = _objects.last;
+        final keep = object.adapter.end(object, widget.color);
+        if (!keep) {
+          _removeLastObject();
+        }
       }
+      _endInteraction();
+    }
+  }
+
+  bool _trySelectObject(Offset focalPoint, Matrix4 transform) {
+    if (widget.adapter.selectEnabled) {
+      for (final object in _objects.reversed) {
+        if (object.adapter.querySelect(object, focalPoint, transform)) {
+          _selectObject(object);
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  void _startInteraction() {
+    setState(() {
+      _hasActiveInteraction = true;
+    });
+  }
+
+  void _endInteraction() {
+    setState(() {
       _hasActiveInteraction = false;
     });
+  }
+
+  void _addObject(DrawObject object) {
+    setState(() {
+      _objects.add(object);
+    });
+  }
+
+  void _removeLastObject() {
+    setState(() {
+      _objects.removeLast();
+    });
+  }
+
+  void _selectObject(DrawObject object) {
+    _selectedObject = object;
+    object.adapter.select(object);
+    widget.onSelectionStart?.call(_selectedObject!);
+  }
+
+  void _cancelSelectObject() {
+    final object = _selectedObject!;
+    widget.onSelectionEnd?.call(object);
+    object.adapter.cancelSelect(object);
+    _selectedObject = null;
+    _endInteraction();
   }
 }

--- a/lib/src/window_paint_controller.dart
+++ b/lib/src/window_paint_controller.dart
@@ -23,7 +23,8 @@ class WindowPaintController extends ValueNotifier<WindowPaintValue> {
 
   /// The current paint mode being used.
   String get mode => value.mode;
-  // The color of the paint tool.
+
+  /// The color of the paint tool.
   Color get color => value.color;
 
   /// Setting this will notify all the listeners of this [WindowPaintController]
@@ -32,9 +33,9 @@ class WindowPaintController extends ValueNotifier<WindowPaintValue> {
   /// actions, not during the build, layout, or paint phases.
   ///
   /// This property can be set from a listener added to this
-  /// [WindowPaintController]; however, one should not also set [color]
-  /// in a separate statement. To change both the [mode] and the [color]
-  /// change the controller's [value].
+  /// [WindowPaintController]; however, one should not also set [color] in a
+  /// separate statement. To change both the [mode] and the [color] change the
+  /// controller's [value].
   set mode(String newMode) {
     value = value.copyWith(
       mode: newMode,
@@ -47,9 +48,9 @@ class WindowPaintController extends ValueNotifier<WindowPaintValue> {
   /// actions, not during the build, layout, or paint phases.
   ///
   /// This property can be set from a listener added to this
-  /// [WindowPaintController]; however, one should not also set [mode]
-  /// in a separate statement. To change both the [mode] and the [color]
-  /// change the controller's [value].
+  /// [WindowPaintController]; however, one should not also set [mode] in a
+  /// separate statement. To change both the [mode] and the [color] change the
+  /// controller's [value].
   set color(Color newColor) {
     value = value.copyWith(
       color: newColor,

--- a/lib/window_paint.dart
+++ b/lib/window_paint.dart
@@ -5,6 +5,7 @@ export 'package:window_paint/src/draw/adapters/pan_zoom_adapter.dart';
 export 'package:window_paint/src/draw/draw_object.dart';
 export 'package:window_paint/src/draw/draw_object_adapter.dart';
 export 'package:window_paint/src/draw/draw_point.dart';
+export 'package:window_paint/src/geometry/line.dart';
 export 'package:window_paint/src/utils/simplify_utils.dart';
 export 'package:window_paint/src/window_paint.dart';
 export 'package:window_paint/src/window_paint_canvas.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -143,7 +143,7 @@ packages:
     source: hosted
     version: "1.3.0-nullsafety.5"
   vector_math:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: vector_math
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,21 +1,24 @@
 name: window_paint
-description: WindowPaint lets you pan, zoom and paint over any other widget. It uses the new InteractiveViewer together with a CustomPainter, giving you the bare minimum to get you started.
+description: WindowPaint lets you pan, zoom and paint over any other widget. It
+  uses the new InteractiveViewer together with a CustomPainter, giving you the
+  bare minimum to get you started.
 version: 0.1.0-nullsafety.1
 homepage: https://github.com/Allvis-AS/window_paint
 repository: https://github.com/Allvis-AS/window_paint
 issue_tracker: https://github.com/Allvis-AS/window_paint/issues
 
 environment:
-  sdk: '>=2.12.0-133.2.beta <3.0.0'
+  sdk: ">=2.12.0-133.2.beta <3.0.0"
   flutter: ">=1.17.0"
 
 dependencies:
   flutter:
     sdk: flutter
+  vector_math: ^2.1.0-nullsafety.5
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   pedantic: ^1.10.0-nullsafety
 
-flutter:
+flutter: null


### PR DESCRIPTION
This PR brings support for object selection.
The default `DrawObject` and `DrawObjectAdapter` implementations demonstrate this functionality.
Both simple (AABB) and complex (OBB) hit-testing techniques have been implemented, and are great starting points for more complex scenarios.

The following has NOT been implemented yet (will come at a later point):
* The ability to **move** a selected object (this is possible to do, but missing a reference implementation)
* The ability to **resize** a selected object *(this is possible to do, but missing a reference implementation)*
* The ability to **remove** a selected object (this requires a change in `WindowPaintController`)